### PR TITLE
Fix overlapping conveyors in the same path

### DIFF
--- a/evaluation.go
+++ b/evaluation.go
@@ -96,35 +96,26 @@ func (s *Scenario) checkEgressesHaveSingleIngress(solution Solution) bool {
 }
 
 func (s *Scenario) checkValidity(solution Solution) error {
-	mines := make([]Mine, len(solution.mines))
 	for i, mine := range solution.mines {
-		mines[i] = mine
-	}
-	factories := make([]Factory, len(solution.factories))
-	for i, factory := range solution.factories {
-		factories[i] = factory
-	}
-	paths := make([]Path, len(solution.paths))
-	for i, path := range solution.paths {
-		paths[i] = path
-	}
-	for i, mine := range solution.mines {
-		if !s.positionAvailableForMine(factories, mines[:i], paths, mine) {
+		if !s.positionAvailableForMine(solution.factories, solution.mines[:i], solution.paths, mine) {
 			return errors.New("solution includes a mine which position is invalid, can't evaluate this solution")
 		}
 	}
 
 	for i, factory := range solution.factories {
-		if !s.positionAvailableForFactory(factories[:i], mines, paths, factory.position) {
+		if !s.positionAvailableForFactory(solution.factories[:i], solution.mines, solution.paths, factory.position) {
 			return errors.New("solution includes a factory which position is invalid, can't evaluate this solution")
 		}
 	}
 
+	paths := make([]Path, len(solution.paths))
 	for i, path := range solution.paths {
+		paths = append(paths, Path{})
 		for _, conveyor := range path.conveyors {
-			if !s.positionAvailableForConveyor(factories, mines, paths[:i], conveyor) {
+			if !s.positionAvailableForConveyor(solution.factories, solution.mines, paths, conveyor) {
 				return errors.New("solution includes a factory which position is invalid, can't evaluate this solution")
 			}
+			paths[i].conveyors = append(paths[i].conveyors, conveyor)
 		}
 	}
 	if !s.checkEgressesHaveSingleIngress(solution) {

--- a/evaluation_test.go
+++ b/evaluation_test.go
@@ -103,3 +103,14 @@ func TestSolutionWithOverlappingConveyorsIsInvalid(t *testing.T) {
 		t.Errorf("invalid solution with overlapping conveyorrs should be invalid")
 	}
 }
+
+func TestSolutionWithOverlappingConveyorsInSamePathIsInvalid(t *testing.T) {
+	scenario := largeEmptyScenario()
+	solution := Solution{paths: []Path{{
+		conveyors: []Conveyor{{position: Position{x: 3, y: 3}, direction: Right, length: Long}, {position: Position{x: 3, y: 3}, direction: Left, length: Long}},
+	}}}
+	err := scenario.checkValidity(solution)
+	if err == nil {
+		t.Errorf("invalid solution with overlapping conveyorrs should be invalid")
+	}
+}


### PR DESCRIPTION
In our software, conveyors in the same path may overlap and produce invalid solutions (in the picture, there are two conveyors with different directions in the same position):

![image](https://user-images.githubusercontent.com/25486288/203968290-fc09e959-7267-479c-9e97-f9a32768af0d.png)

These changes add a test case and fix the behavior.