### PR TITLE
Revert changes in priorityQueue.go

### DIFF
--- a/priorityQueue.go
+++ b/priorityQueue.go
@@ -16,7 +16,7 @@ type PriorityQueue []*Item
 func (pq PriorityQueue) Len() int { return len(pq) }
 
 func (pq PriorityQueue) Less(i, j int) bool {
-	// We want Pop to give us the lowest, not highest, priority so we use smaller than here.
+	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
 	return pq[i].priority > pq[j].priority
 }
 


### PR DESCRIPTION
I tested our software on a few examples. With the current setting in `priorityQueue.go`, we build paths that are too long, e.g. in `task.002.json`.

In the current implementation, we get score 80:

![image](https://user-images.githubusercontent.com/25486288/209838585-f33977a1-5c94-467e-80a0-b9c06b16434c.png)


In the original implementation, we get score 90:

![image](https://user-images.githubusercontent.com/25486288/209838492-ee37858b-fd2d-4e6e-b1b2-e8eb6a5cc068.png)
