### PR TITLE
Add go memory management vars to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ENV CGO_CFLAGS="-I/usr/include/lpsolve" \
     CGO_LDFLAGS="-llpsolve55 -lm -ldl -lcolamd"
 
 WORKDIR /app
+ENV GOMEMLIMIT=1800MiB
+ENV GOGC=off
 
 COPY go.mod go.sum ./
 


### PR DESCRIPTION
Disable scheduling of GC and enforce a memory limit instead. This should lower the amount of GC cycles that occur.